### PR TITLE
Fix compile error

### DIFF
--- a/ogg.framework/Headers/os_types.h
+++ b/ogg.framework/Headers/os_types.h
@@ -68,7 +68,7 @@
 
 #elif (defined(__APPLE__) && defined(__MACH__)) /* MacOS X Framework build */
 
-//#  include <inttypes.h>
+#  include <sys/types.h>
    typedef int16_t ogg_int16_t;
    typedef uint16_t ogg_uint16_t;
    typedef int32_t ogg_int32_t;


### PR DESCRIPTION
Fix  "Declaration of 'int16_t' must be imported from module 'Darwin.POSIX.sys.types._int16_t' before it is required"